### PR TITLE
ThinPtr type

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: beta
           override: true
       - name: Test with all features
         uses: actions-rs/cargo@v1
@@ -30,7 +30,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: beta
           override: true
           components: rustfmt
       - name: Check formatting
@@ -48,7 +48,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: beta
           override: true
           components: clippy
       - name: Check style

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,10 +429,10 @@ impl<Head, SliceItem> ThinArc<Head, SliceItem> {
     }
 }
 
-impl<Head, SliceItem> Into<Arc<ThinData<Head, SliceItem>>> for ThinArc<Head, SliceItem> {
-    fn into(self) -> Arc<ThinData<Head, SliceItem>> {
+impl<Head, SliceItem> From<ThinArc<Head, SliceItem>> for Arc<ThinData<Head, SliceItem>> {
+    fn from(this: ThinArc<Head, SliceItem>) -> Self {
         unsafe {
-            let this = ManuallyDrop::new(self);
+            let this = ManuallyDrop::new(this);
             Arc::from_raw(ThinData::fatten_const(this.raw).as_ptr())
         }
     }
@@ -488,10 +488,10 @@ impl<Head, SliceItem> ThinRc<Head, SliceItem> {
     }
 }
 
-impl<Head, SliceItem> Into<Rc<ThinData<Head, SliceItem>>> for ThinRc<Head, SliceItem> {
-    fn into(self) -> Rc<ThinData<Head, SliceItem>> {
+impl<Head, SliceItem> From<ThinRc<Head, SliceItem>> for Rc<ThinData<Head, SliceItem>> {
+    fn from(this: ThinRc<Head, SliceItem>) -> Self {
         unsafe {
-            let this = ManuallyDrop::new(self);
+            let this = ManuallyDrop::new(this);
             Rc::from_raw(ThinData::fatten_const(this.raw).as_ptr())
         }
     }


### PR DESCRIPTION
Closes #5

And makes the macro even more weird....

The trait impls now delegate to the fat impl rather than the ThinData behind the pointer, so that we work more generally with pointers of unknown provenance. I also slipped a PartialEq generalization in there.

r? @matklad