### PR TITLE
Sanity-check layout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,7 @@ impl<Head, SliceItem> ThinBox<Head, SliceItem> {
                 items.next().is_none(),
                 "ExactSizeIterator under-reported length"
             );
+            assert_eq!(layout, Layout::for_value(ptr.as_ref()));
             Self::from_erased(ThinData::erase(ptr))
         }
     }


### PR DESCRIPTION
I *think* that this checks that our usage of `Box::from_raw` is valid. 